### PR TITLE
Add shutdown() hook to flush SDK impressions on process exit

### DIFF
--- a/dbt_feature_flags/base.py
+++ b/dbt_feature_flags/base.py
@@ -59,6 +59,16 @@ class BaseFeatureFlagsClient(abc.ABC):
             "JSON feature flags are not implemented for this driver"
         )
 
+    def shutdown(self) -> None:
+        """Flush queued data and cleanly close the SDK client on process exit.
+
+        Called automatically via atexit when patch_dbt_environment() initialises
+        a real provider.  Override in provider subclasses that need to flush
+        impressions or events before the process exits.  The default
+        implementation is a no-op so that providers which register their own
+        atexit handlers (e.g. FME, LaunchDarkly) are unaffected.
+        """
+
 
 def validate(types: t.Tuple[t.Type[t.Any], ...]):
     def _validate(v, flag_name, func_name):

--- a/dbt_feature_flags/harness.py
+++ b/dbt_feature_flags/harness.py
@@ -81,6 +81,13 @@ class HarnessFeatureFlagsClient(BaseFeatureFlagsClient):
         self.client = CfSyncClient(FF_KEY)
         super().__init__()
 
+    def shutdown(self) -> None:
+        """Close the HFF client connection and flush any pending analytics."""
+        try:
+            self.client.destroy()
+        except Exception:
+            pass
+
     def bool_variation(self, flag: str, default: bool = False) -> bool:
         return self.client.bool_variation(flag, target=self.target, default=default)
 

--- a/dbt_feature_flags/patch.py
+++ b/dbt_feature_flags/patch.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import atexit
 import os
 import typing as t
 from enum import Enum
@@ -101,8 +102,12 @@ def patch_dbt_environment() -> None:
     """Patch dbt's jinja environment to include feature flag functions."""
     from dbt.clients import jinja
 
+    client = _get_client()
     jinja._get_rendered = jinja.get_rendered
-    jinja.get_rendered = get_rendered(jinja._get_rendered, _get_client())
+    jinja.get_rendered = get_rendered(jinja._get_rendered, client)
+
+    if isinstance(client, base.BaseFeatureFlagsClient):
+        atexit.register(client.shutdown)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
Providers that buffer data (impressions, analytics events) can silently
drop queued items when the dbt process exits. This is most visible with
the Harness HFF SDK, which has no cleanup registered at all.

## Changes
- `base.py` — adds `shutdown()` as a no-op on `BaseFeatureFlagsClient`
- `harness.py` — overrides `shutdown()` to call `client.destroy()`
- `patch.py` — registers `client.shutdown` via `atexit` inside
  `patch_dbt_environment()`, so all providers get a consistent exit hook

## Notes
FME and LaunchDarkly already register their own `atexit` handlers internally, so `shutdown()` is a no-op for those providers and existing behavior is unchanged.
