### PR TITLE
Fix pre-existing CI failures across dbt version matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,9 +34,9 @@ jobs:
           python-version: "3.10"
       - name: Install dbt ${{ matrix.dbt-version }}
         if: matrix.dbt-version != 1.0
-        run: pip install . dbt-core==${{ matrix.dbt-version }} pytest
+        run: pip install . dbt-core==${{ matrix.dbt-version }} pytest pytz
       - name: Install dbt ${{ matrix.dbt-version }} (with Markupsafe pin)
         if: matrix.dbt-version == 1.0
-        run: pip install . dbt-core==${{ matrix.dbt-version }} pytest markupsafe==2.0.1
+        run: pip install . dbt-core==${{ matrix.dbt-version }} pytest pytz markupsafe==2.0.1
       - name: Run Tests
         run: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""pytest configuration for dbt-feature-flags tests.
+
+Handles dbt version differences that affect test setup:
+
+- dbt 1.5 added MACRO_DEBUGGING to the global flags Namespace.  Without
+  calling set_from_args() the attribute is absent, which causes an
+  AttributeError inside dbt's jinja._compile() when tests render templates.
+  We set it to False (the correct default for non-debug runs) before the
+  test session starts.
+"""
+
+
+def pytest_configure(config) -> None:
+    """Seed missing dbt flag attributes required by dbt 1.5+."""
+    try:
+        from dbt.flags import get_flags  # only present in dbt 1.5+
+
+        flags = get_flags()
+        if not hasattr(flags, "MACRO_DEBUGGING"):
+            flags.MACRO_DEBUGGING = False
+    except Exception:
+        # Older dbt versions do not expose get_flags — nothing to do.
+        pass


### PR DESCRIPTION
## Problem
All tests were failing on every PR due to two pre-existing CI issues,
making it impossible to validate any contributions.

## Fix 1 — `pytz` not installed (dbt 1.0–1.4)
Older dbt-core versions import `pytz` directly in `dbt/tracking.py`.
The pip install step didn't include it explicitly, causing
`ModuleNotFoundError` before any test could run.

**Change:** added `pytz` to both install steps in `run-tests.yml`.

## Fix 2 — `MACRO_DEBUGGING` missing from flags Namespace (dbt 1.5)
dbt 1.5 added `MACRO_DEBUGGING` to the global flags `Namespace`,
populated via `set_from_args()` during normal dbt startup. Tests bypass
that startup, leaving the attribute absent and causing `AttributeError`
inside `dbt/clients/jinja.py` when templates are rendered.

**Change:** added `tests/conftest.py` with a `pytest_configure` hook
that sets `MACRO_DEBUGGING = False` when the attribute is missing.
The hook is version-safe — it no-ops on dbt versions that don't expose
`dbt.flags.get_flags`.
